### PR TITLE
Add missing dependencies: `PyMuPDF` and `langid` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -113,3 +113,5 @@ xxhash==3.5.0
 yarl==1.15.2
 zipp==3.20.2
 pycocotools==2.0.7
+PyMuPDF==1.24.11
+langid==1.1.6


### PR DESCRIPTION
Added two missing dependencies to requirements.txt that are used by the codebase but were not previously included:

- `PyMuPDF==1.24.11` - Required by `tools/model_infer/mathpix_img2md.py` for PDF processing
- `langid==1.1.6` - Required by `tools/json2md.py` for language detection during markdown conversion