### PR TITLE
fix PP-StructureV3 End-to-End Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,20 +463,20 @@ End-to-end evaluation assesses the model's accuracy in parsing PDF page content.
     </tr>
     <tr>
       <td>PaddleOCR PP-StructureV3</sup></td>
-      <td>0.152</td>
-      <td>0.223</td>
-      <td>0.073</td>
-      <td>0.136</td>
+      <td>0.145</td>
+      <td>0.206</td>
+      <td>0.058</td>
+      <td>0.088</td>
       <td>0.295</td>
       <td>0.535</td>
-      <td>81.8</td>
-      <td>52.1</td>
-      <td>76.1</td>
-      <td>82.7</td>
-      <td>0.162</td>
-      <td>0.111</td>
-      <td>0.077</td>
-      <td>0.11</td>
+      <td>-</td>
+      <td>-</td>
+      <td>77.2</td>
+      <td>83.9</td>
+      <td>0.159</td>
+      <td>0.109</td>
+      <td>0.069</td>
+      <td>0.091</td>
     </tr>
     <tr>
       <td>Mathpix</sup></td>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -453,20 +453,20 @@ result/
     </tr>
     <tr>
       <td>PaddleOCR PP-StructureV3</sup></td>
-      <td>0.152</td>
-      <td>0.223</td>
-      <td>0.073</td>
-      <td>0.136</td>
+      <td>0.145</td>
+      <td>0.206</td>
+      <td>0.058</td>
+      <td>0.088</td>
       <td>0.295</td>
       <td>0.535</td>
-      <td>81.8</td>
-      <td>52.1</td>
-      <td>76.1</td>
-      <td>82.7</td>
-      <td>0.162</td>
-      <td>0.111</td>
-      <td>0.077</td>
-      <td>0.11</td>
+      <td>-</td>
+      <td>-</td>
+      <td>77.2</td>
+      <td>83.9</td>
+      <td>0.159</td>
+      <td>0.109</td>
+      <td>0.069</td>
+      <td>0.091</td>
     </tr>
     <tr>
       <td>Mathpix</sup></td>


### PR DESCRIPTION
Hello! We have noticed inconsistencies between the evaluation metrics and actual performance of PP-StructureV3 in your project. This is because, by default, PP-StructureV3 applies document orientation classification, layout correction, and beautifies the Markdown output to enhance readability, which may affect evaluation accuracy. We recommend explicitly setting `use_doc_orientation_classify=False`, `use_textline_orientation=False`, and `use_doc_unwarping=False` in the `predict()` method, and setting `pretty=False` in the `save_to_markdown()` method to obtain accurate evaluation results. This PR provides the corrected evaluation results, along with sample evaluation code below. If you encounter any issues during evaluation, please feel free to contact us.

```
from paddleocr import PPStructureV3

pipeline = PPStructureV3()
error_files = []
file_list_txt = "file_list.txt"
with open(file_list_txt, 'r', encoding='utf-8') as f:
    file_list = f.readlines()

for file in file_list:
    file = file.strip("\n")
    file_suffix = file.split(".")[-1]
    file_name = file.replace('.', '_').replace('/', '_').strip()
    output = pipeline.predict(
        f"./minibench/{file}",
        use_doc_orientation_classify=False,
        use_doc_unwarping=False,
        use_textline_orientation = False,
    )
    out_dir = f"./output/{file_name}"
    for res in output:
        res.save_to_json(out_dir)
        res.save_to_markdown(out_dir,pretty=False)
```