### PR TITLE
Update PyNomaly version to 0.3.4 from 0.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ ptyprocess==0.7.0
 pyarrow==17.0.0
 Pygments==2.18.0
 pylatexenc==3.0a30
-PyNomaly==0.3.3
+PyNomaly==0.3.4
 pyparsing==3.1.4
 pyrsistent==0.18.1
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
This PR updates the PyNomaly version from `0.3.3` to the latest version `0.3.4` (I'm the author of the PyNomaly software). 