### PR TITLE
config: make worker defaults explicit

### DIFF
--- a/configs/end2end.yaml
+++ b/configs/end2end.yaml
@@ -7,10 +7,14 @@ end2end_eval:
       metric:
       - Edit_dist
       - CDM
+      # Keep each stage around 1/3 to 1/2 of idle CPUs to avoid deadlocks.
+      cdm_workers: 13
     table:
       metric:
       - TEDS
       - Edit_dist
+      # Keep each stage around 1/3 to 1/2 of idle CPUs to avoid deadlocks.
+      teds_workers: 13
     reading_order:
       metric:
       - Edit_dist
@@ -21,6 +25,8 @@ end2end_eval:
     prediction:
       data_path: ./demo_data/end2end
     match_method: quick_match
+    # Keep each stage around 1/3 to 1/2 of idle CPUs to avoid deadlocks.
+    match_workers: 13
     quick_match_truncated_timeout_sec: 300
     match_timeout_sec: 420
     timeout_fallback_max_chunk_span: 10


### PR DESCRIPTION
This PR is stacked on top of #211.

Relative to #211, the only additional change is in `configs/end2end.yaml`:
- set `dataset.match_workers: 13`
- set `metrics.table.teds_workers: 13`
- set `metrics.display_formula.cdm_workers: 13`
- add a short note recommending each stage stay around 1/3 to 1/2 of idle CPUs to reduce deadlock risk

Because GitHub PR base must be a branch in the upstream repository, this PR is opened against `main` and therefore includes the already-pending #211 changes in the full diff. Please review it as a stacked change on top of #211.
