### PR TITLE
Fix pred_idx=0 metadata handling in match_gt2pred_simple

### DIFF
--- a/src/core/matching/match.py
+++ b/src/core/matching/match.py
@@ -698,7 +698,7 @@ def match_gt2pred_simple(gt_items, pred_items, line_type, img_name):
             pred_line = ""
             norm_pred_line = ""
             edit = 1
-        
+        has_pred = pred_idx != ""
 
         match_list.append({
             'gt_idx': [gt_idx],
@@ -710,8 +710,8 @@ def match_gt2pred_simple(gt_items, pred_items, line_type, img_name):
             'pred_idx': [pred_idx],
             'pred': pred_line,
             'norm_pred': norm_pred_line,
-            'pred_category_type': get_pred_category_type(pred_idx, pred_items) if pred_idx else "",
-            'pred_position': pred_items[pred_idx]['position'][0] if pred_idx else "",
+            'pred_category_type': get_pred_category_type(pred_idx, pred_items) if has_pred else "",
+            'pred_position': pred_items[pred_idx]['position'][0] if has_pred else "",
             'edit': edit,
             'img_id': img_name
         })

--- a/tests/test_match_gt2pred_simple.py
+++ b/tests/test_match_gt2pred_simple.py
@@ -1,0 +1,27 @@
+from src.core.matching.match import match_gt2pred_simple
+
+
+def test_match_gt2pred_simple_keeps_metadata_for_pred_index_zero():
+    gt_items = [
+        {
+            "category_type": "table",
+            "html": "<table><tr><td>A</td></tr></table>",
+            "order": 2,
+            "attribute": {},
+        }
+    ]
+    pred_items = [
+        {
+            "category_type": "html_table",
+            "content": "<table><tr><td>A</td></tr></table>",
+            "position": [2, 3],
+        }
+    ]
+
+    matches, unmatched = match_gt2pred_simple(gt_items, pred_items, "html_table", "mini.png")
+
+    assert unmatched is None
+    assert matches[0]["pred_idx"] == [0]
+    assert matches[0]["edit"] == 0
+    assert matches[0]["pred_category_type"] == "html_table"
+    assert matches[0]["pred_position"] == 2


### PR DESCRIPTION
## Summary
- Treat `pred_idx = 0` as a valid matched prediction in `match_gt2pred_simple`
- Preserve `pred_category_type` and `pred_position` for the first matched prediction
- Add a regression test for the one-table `pred_idx = 0` case

Fixes #229.

## Test
- Passed: inline Python regression script for `match_gt2pred_simple` with `pred_idx = 0`
- Not run: `python -m pytest tests/test_match_gt2pred_simple.py -q` because pytest is not installed in the dev environment