### PR TITLE
Fix table-to-text rescue not wired into text matching (#238)

### DIFF
--- a/src/dataset/end2end_dataset.py
+++ b/src/dataset/end2end_dataset.py
@@ -31,6 +31,7 @@ from src.core.preprocess import (
     textblock2unicode,
     textblock_with_norm_formula,
 )
+from src.core.matching.match import split_pred_table_to_text_items
 from src.core.registry import DATASET_REGISTRY
 from src.dataset.table_dataset import RecognitionTableDataset
 from src.runtime.concurrency import resolve_match_workers
@@ -2182,12 +2183,20 @@ class End2EndDataset():
                 converted_item['fine_category_type'] = converted_item.get('fine_category_type', 'latex2html_table')
                 pred_table_candidates.append(converted_item)
 
+        unmatch_table_pred = []
         if gt_page_elements.get('table'):
             stage_start = time.monotonic()
             gt_table = self.get_sorted_text_list(gt_page_elements['table'])
             html_table_match_s, unmatch_table_pred = match_gt2pred_simple(gt_table, pred_table_candidates, 'html_table', img_name)
+            unmatch_table_pred = unmatch_table_pred or []
             html_table_match_s = [x for x in html_table_match_s if x['gt_idx'] != [""]]  # Remove extra preds
             self._log_slow_stage(img_name, 'table_match', stage_start)
+        elif pred_table_candidates:
+            # GT has no table but the model emitted one(s): linearize to plain text
+            # and feed into the same text-matching pipeline (issue #238).
+            unmatch_table_pred = split_pred_table_to_text_items(pred_table_candidates)
+        if unmatch_table_pred:
+            pred_dataset_mix.extend(unmatch_table_pred)
 
         stage_start = time.monotonic()
         try:


### PR DESCRIPTION
## Summary

Fixes #238.

When a page's ground truth contains **no table** but the model outputs that region **as a table**, the end-to-end matcher extracts the table (`html_table` / `md2html_table` / `latex_table`) and then **drops it**. The corresponding GT text rows are left unmatched (`Edit_dist = 1.0`, empty `pred_category_type`), so identical content is scored very differently depending only on output format.

The technical report states that such mis-recognized tables should be **linearized back to plain text and matched in the same pipeline**. The helper `split_pred_table_to_text_items` (and `table_to_text_lines`) already implements the linearization, but it was **never wired into** `process_get_matched_elements` — the `unmatch_table_pred` it returns was received and then unused, and the GT-no-table case never reached it at all.

## Fix

In `process_get_matched_elements` (`src/dataset/end2end_dataset.py`):

- **GT-no-table pages**: linearize predicted tables via `split_pred_table_to_text_items` and add them to the text-matching pool (`pred_dataset_mix`).
- **GT-has-table pages**: also feed the leftover unmatched predicted tables (the `unmatch_table_pred` that was previously dropped) into the text pool.

9 added lines, 1 file, no deletions.

## Verification

Minimal repro from the issue (identical content, text vs markdown-table prediction, GT is plain text):

| prediction format | text_block Edit_dist (before) | (after) |
|---|---|---|
| plain text | 0.000 | 0.000 |
| markdown table | **1.000** | **0.000** |

After the fix, the rescued rows match with `pred_category_type = table_to_text`, confirming the previously-dead path is exercised.

**Table TEDS and formula (CDM) metrics are unaffected** — verified unchanged on GT-has-table pages; only `text_block` / `reading_order` matching gains the previously-dropped content.
