### PR TITLE
Add EvalScope integration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Currently supported metrics include:
 
 ## Updates
 
+[2026/07/27] Added a community-maintained [EvalScope](https://github.com/modelscope/evalscope) integration for running OmniDocBench with OpenAI-compatible model endpoints and standardized predictions, metrics, and reports. See the EvalScope guide: https://evalscope.readthedocs.io/en/latest/benchmarks/omni_doc_bench.html
+
 [2026/04/30] Updated from **v1.6** to **v1.7**, added the Qianfan-OCR leaderboard, and supported skills-based evaluation.
 
 [2026/04/10] **Major update**: Updated from **v1.5** to **v1.6**


### PR DESCRIPTION
This PR adds a short Updates entry for the EvalScope integration after the maintainers indicated a README/Docs PR would be welcome.

Related issue: https://github.com/opendatalab/OmniDocBench/issues/249
EvalScope docs: https://evalscope.readthedocs.io/en/latest/benchmarks/omni_doc_bench.html
EvalScope repo: https://github.com/modelscope/evalscope